### PR TITLE
fixed the text for home credit page using flex box

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,15 +187,17 @@
 
     <!-- Credit page-->
     <section class="bg-purple">
-        <div class="text-center container px-1">
+        <div class="text-center container px-5">
             <h2 class="text-white">Credits</h2>
-            <p class="text-white">Teachers, coaches, and leaders of these three districts are <br>striving to make Edsight better: Metro-Nashville Public Schools <br>(Tennessee), Federal Way Public Schools (Washington) and San <br>Francisco Unified (California).<br></p>
-            <p class="text-white">Edsight is the result of a large-scale collaboration between the <br> University of Washington, UC Riverside, UC Irvine, Vanderbilt,<br> Stanford and New York University.</p>
-            <p class="text-white">The icons used in Edsight were designed by creative artists who <br> made their works available through The Noun Project. All<br> images are licensed through Creative Commons. We thank<br> everyone that put efforts in creating these beautiful, intuitive<br> and free materials. </p>
             
+            <div class="row align-items-center justify-content-center">
+                <p class="text-white col-lg-7">Teachers, coaches, and leaders of these three districts are striving to make Edsight better: Metro-Nashville Public Schools (Tennessee), Federal Way Public Schools (Washington) and San Francisco Unified (California).</p>
+                <p class="text-white col-lg-7">Edsight is the result of a large-scale collaboration between the University of Washington, UC Riverside, UC Irvine, Vanderbilt, Stanford and New York University.</p>
+                <p class="text-white col-lg-7">The icons used in Edsight were designed by creative artists who made their works available through The Noun Project. All images are licensed through Creative Commons. We thank everyone that put efforts in creating these beautiful, intuitive and free materials. </p>
+                <p class="text-white col-lg-7">Research Program supported by the National Science Foundation under Grants DRL-1620851, DRL-1621238, DRL-1620863, DRL-1911492</p>
+            </div>
             
-            <p class="text-white">Research Program supported by the National Science Foundation under<br> Grants DRL-1620851, DRL-1621238, DRL-1620863, DRL-1911492</p>
-            <img class="py-4" src="assets/img/ncf-logo.png">
+            <img class="py-1 img-fluid" src="assets/img/ncf-logo.png">
         </div>
     </section>
 


### PR DESCRIPTION
<img width="966" alt="Screen Shot 2022-11-26 at 00 39 18" src="https://user-images.githubusercontent.com/76905887/204080185-fe3adfdf-3d15-4081-87b9-c139c43071a3.png">
<img width="971" alt="Screen Shot 2022-11-26 at 00 39 31" src="https://user-images.githubusercontent.com/76905887/204080192-4257748b-6b5c-4644-9e00-d7b77f93cc7e.png">
No more using <br>, instead they all changed to using flex box.